### PR TITLE
Apply patch to fix draft blank pages.

### DIFF
--- a/dkan_workflow.make
+++ b/dkan_workflow.make
@@ -22,6 +22,7 @@ projects[workbench][subdir] = contrib
 projects[workbench_moderation][version] = 1.4
 projects[workbench_moderation][subdir] = contrib
 projects[workbench_moderation][patch][2393771] = https://www.drupal.org/files/issues/specify_change_state_user-2393771-5.patch
+projects[workbench_moderation][patch][1838640] = https://www.drupal.org/files/issues/workbench_moderation-fix_callback_argument-1838640-23.patch
 
 projects[workbench_email][version] = 3.4
 projects[workbench_email][subdir] = contrib


### PR DESCRIPTION
Ref: https://github.com/NuCivic/healthdata/issues/440
Ref: https://www.drupal.org/node/1838640#comment-10354315

Acceptance:

Fixes regression issue in healthdata such that drafts do not appear as blank page.
