### PR TITLE
Add a transition email proxy to control email delivery.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ before_script:
 
 script:
   - bin/behat features/data_workflow.feature
+  - bin/phpunit phpunit/DkanWorkflowEmailTransition.php
+  - bin/phpunit phpunit/DkanWorkflowTest.php
 
 notifications:
   slack:

--- a/dkan_workflow.email_proxy.inc
+++ b/dkan_workflow.email_proxy.inc
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @file
+ * Implements a transition email proxy for dkan_workflow.
+ *
+ * The business logic we wish to capture:
+ * Allow email send if the user is the origional author of the node.
+ *
+ * Only allow emails to "Worflow Moderator" that are in the same group as the
+ * node.
+ *
+ * If the node does not belong to a group, then only allow emails to users
+ * that belong to the "Workflow Supervisor" role.
+ *
+ * If the node belongs to a group do not email the "Workflow Supervisor".
+ */
+
+/**
+ * Implemenation of the a transition email proxy.
+ */
+class DkanWorkflowEmailProxy {
+  /**
+   * Constructor function.
+   */
+  public function __construct($message) {
+    $this->roles = array_flip(user_roles());
+    $this->node = $message['params']['node'];
+    $this->user = user_load_by_mail($message['to']);
+  }
+
+  /**
+   * Decision process for sending messages.
+   */
+  public function send() {
+    return $this->isCreator() || $this->isGroupModerator() || $this->isUngroupedSupervisor();
+  }
+
+  /**
+   * Allow emails to creator of the node.
+   */
+  private function isCreator() {
+    return ($this->user->uid == $this->node->uid);
+  }
+
+  /**
+   * Allow emails to group Moderators that share same group as node.
+   */
+  private function isGroupModerator() {
+    if (user_has_role($this->roles['Workflow Moderator'], $this->user)) {
+      $user_groups = og_get_entity_groups('user', $this->user);
+      $node_groups = og_get_entity_groups('node', $this->node);
+      $intersect = array_intersect($user_groups, $node_groups);
+      return !empty($intersect);
+    }
+    return FALSE;
+  }
+
+  /**
+   * Allow emails to Supervisors for groupless nodes.
+   */
+  private function isUngroupedSupervisor() {
+    if (user_has_role($this->roles['Workflow Supervisor'], $this->user)) {
+      if (empty(og_get_entity_groups('node', $this->node))) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+}

--- a/dkan_workflow.module
+++ b/dkan_workflow.module
@@ -99,7 +99,26 @@ function dkan_workflow_views_default_views_alter(&$views) {
 function dkan_workflow_form_alter(&$form, $form_state, $form_id) {
   if ($form_id == 'views_exposed_form' && strpos($form_state['view']->name, 'workbench_') === 0) {
     dkan_workflow_limit_workflow_exposed_filter_node_types($form);
+    dkan_workflow_remove_email_errors();
   }
+}
+
+/**
+ * Removes email errors from drupal messages.
+ */
+function dkan_workflow_remove_email_errors() {
+  $messages = drupal_get_messages('error');
+  if ($messages['error']) {
+    $messages['error'] = array_filter($messages['error'], function ($item) {
+      return FALSE === strpos($item, 'email notifications');
+    });
+  }
+
+  $drupal_set_error = function($error) {
+    drupal_set_message($error, 'error');
+  };
+
+  array_map($drupal_set_error, $messages['error']);
 }
 
 /**
@@ -113,6 +132,27 @@ function dkan_workflow_limit_workflow_exposed_filter_node_types(&$form) {
 
   $form['type']['#default_value'] = 'Dataset';
   $form['type']['#validated'] = TRUE;
+}
+
+/**
+ * Implements hook_strongarm_alter().
+ *
+ * dkan_dataset_content_types exports node_options_(dataset|resource). For
+ * dkan_workflow to work we need to remove 'status' and make sure 'moderation'
+ * and 'revision' from the node_options variable.
+ */
+function dkan_workflow_strongarm_alter(&$data) {
+  foreach (array('dataset', 'resource') as $type) {
+    $var_name = 'node_options_' . $type;
+    if (isset($data[$var_name])) {
+      $node_options = $data[$var_name]->value;
+      // Remove status if set
+      $node_options = array_diff($node_options, array('status'));
+      // Add moderation and revision if needed.
+      $node_options = array_values(array_unique(array_merge($node_options, array('moderation', 'revision')), SORT_REGULAR));
+      $data[$var_name]->value = $node_options;
+    }
+  }
 }
 
 /**
@@ -163,22 +203,12 @@ function dkan_workflow_views_pre_view(&$view, &$display_id, &$args) {
 }
 
 /**
- * Implements hook_strongarm_alter().
- *
- * dkan_dataset_content_types exports node_options_(dataset|resource). For
- * dkan_workflow to work we need to remove 'status' and make sure 'moderation'
- * and 'revision' from the node_options variable.
+ * Implements hook_mail_alter().
  */
-function dkan_workflow_strongarm_alter(&$data) {
-  foreach (array('dataset', 'resource') as $type) {
-    $var_name = 'node_options_' . $type;
-    if (isset($data[$var_name])) {
-      $node_options = $data[$var_name]->value;
-      // Remove status if set
-      $node_options = array_diff($node_options, array('status'));
-      // Add moderation and revision if needed.
-      $node_options = array_values(array_unique(array_merge($node_options, array('moderation', 'revision')), SORT_REGULAR));
-      $data[$var_name]->value = $node_options;
-    }
+function dkan_workflow_mail_alter(&$message) {
+  if (isset($message['id']) && $message['id'] == 'workbench_email_we_transition') {
+    module_load_include('inc', 'dkan_workflow', 'dkan_workflow.email_proxy');
+    $dkan_email_proxy = new DkanWorkflowEmailProxy($message);
+    $message['send'] = $dkan_email_proxy->send();
   }
 }

--- a/test/boot.php
+++ b/test/boot.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @file
+ * Bootstraps Drupal 7 site.
+ */
+
+use Drupal\Driver\DrupalDriver;
+use Drupal\Driver\Cores\Drupal7;
+require 'vendor/autoload.php';
+
+$dir = explode('/sites/', getcwd());
+// Path to Drupal.
+$path = $dir[0];
+
+// Could be inside profiles folder.
+if (count($dir) == 1) {
+  $dir = explode('/profiles/', getcwd());
+  $path = $dir[0];
+}
+
+// Could be inside projects folder.
+if (count($dir) == 1) {
+  $dir = explode('/projects/', getcwd());
+  $path = $dir[0] . '/docroot';
+}
+
+// Host.
+$uri = 'http://localhost';
+
+$driver = new DrupalDriver($path, $uri);
+$driver->setCoreFromVersion();
+
+// Bootstrap Drupal.
+$driver->bootstrap();

--- a/test/composer.json
+++ b/test/composer.json
@@ -1,8 +1,11 @@
 {
-    "require": {
-        "drupal/drupal-extension": "~3.0"
-    },
-    "config": {
-        "bin-dir": "bin/"
-    }
+  "require": {
+    "drupal/drupal-extension": "~3.0",
+    "phpunit/phpunit": "4.6.*",
+    "myplanetdigital/function_mock": "dev-master",
+    "drupal/drupal-driver": "~1.0"
+  },
+  "config": {
+    "bin-dir": "bin/"
+  }
 }

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -1,0 +1,11 @@
+<phpunit backupGlobals="false"
+    backupStaticAttributes="false"
+    syntaxCheck="false"
+    bootstrap="boot.php"
+    colors="true">
+  <testsuites>
+    <testsuite name="HHS Harvest Suite">
+      <directory>.</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/test/phpunit/DkanWorkflowEmailTransition.php
+++ b/test/phpunit/DkanWorkflowEmailTransition.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * @file
+ * Test transition emails for the dkan_workflow via dkan_workflow_mail_alter.
+ *
+ * The business logic we wish to capture:
+ * Allow email send if the user is the origional author of the node.
+ *
+ * Only allow emails to "Worflow Moderator" that are in the same group as the
+ * node.
+ *
+ * If the node does not belong to a group, then only allow emails to users
+ * that belong to the "Workflow Supervisor" role.
+ *
+ * If the node belongs to group do not email with users "Workflow Supervisors".
+ */
+
+module_load_include('module', 'dkan_workflow');
+
+/**
+ * Unit tests for dkan_workflow_mail_alter.
+ */
+class DkanWorkflowMailAlterTest extends PHPUnit_Framework_TestCase {
+
+  /**
+   * Overrides parent::setUp().
+   */
+  public function setUp() {
+    $uniqid = uniqid();
+    $group = (object) [
+      'title' => 'test-group',
+      'type' => 'group',
+      'status' => 1,
+    ];
+    node_save($group);
+    $this->group = $group;
+
+    $group2 = (object) [
+      'title' => 'test-group 2',
+      'type' => 'group',
+      'status' => 1,
+    ];
+    node_save($group2);
+    $this->group2 = $group2;
+
+    $this->roles = array_flip(user_roles());
+    $user = [
+      'name' => 'test-user' . $uniqid,
+      'pass' => 'fake',
+      'mail' => $uniqid . '@gmail.com',
+      'init' => $uniqid . '@gmail.com',
+      'status' => 1,
+      'roles' => array(),
+    ];
+    $this->user = user_save(NULL, $user);
+
+    $node = (object) [
+      'title' => 'test - dataset',
+      'type' => 'dataset',
+      'uid' => 1,
+      'status' => '1',
+    ];
+    node_save($node);
+
+    $message = [
+      'id' => 'workbench_email_we_transition',
+      'params' => [
+        'node' => $node,
+      ],
+    ];
+    $this->message = $message;
+  }
+
+  /**
+   * Verify orgional node creater will get a pass.
+   */
+  public function testOrigUserOfNodePasses() {
+    $this->message['to'] = $this->user->mail;
+    $this->message['params']['node']->uid = $this->user->uid;
+    dkan_workflow_mail_alter($this->message);
+
+    $this->assertTrue($this->message['send']);
+  }
+
+  /**
+   * Verify Workflow Moderator that belongs to same group as node gets a pass.
+   */
+  public function testWorkflowModeratorSameGroupPasses() {
+    $workflow_moderator = $this->roles['Workflow Moderator'];
+    $this->user->roles[$workflow_moderator] = $workflow_moderator;
+    user_save($this->user);
+    $this->message['to'] = $this->user->mail;
+    og_group('node', $this->group->nid, array(
+      'entity_type' => 'user',
+      'entity' => $this->user,
+    ));
+    og_group('node', $this->group->nid, array(
+      'entity_type' => 'node',
+      'entity' => $this->message['params']['node'],
+      'field_name' => 'og_group_ref',
+    ));
+    dkan_workflow_mail_alter($this->message);
+
+    $this->assertTrue($this->message['send']);
+  }
+
+  /**
+   * Verify Workflow Moderator that belongs to multiple groups can pass.
+   *
+   * Making sure that multiple groups does not change outcomes.
+   */
+  public function testWorkflowModeratorMultipleGroupsPasses() {
+    $workflow_moderator = $this->roles['Workflow Moderator'];
+    $this->user->roles[$workflow_moderator] = $workflow_moderator;
+    user_save($this->user);
+    $this->message['to'] = $this->user->mail;
+    og_group('node', $this->group->nid, array(
+      'entity_type' => 'user',
+      'entity' => $this->user,
+    ));
+    og_group('node', $this->group2->nid, array(
+      'entity_type' => 'user',
+      'entity' => $this->user,
+    ));
+    og_group('node', $this->group->nid, array(
+      'entity_type' => 'node',
+      'entity' => $this->message['params']['node'],
+      'field_name' => 'og_group_ref',
+    ));
+    dkan_workflow_mail_alter($this->message);
+
+    $this->assertTrue($this->message['send']);
+  }
+
+  /**
+   * Verify Workflow Moderator that does not share group with  node is stopped.
+   */
+  public function testWorkflowModeratorNoGroupFails() {
+    $role = $this->roles['Workflow Moderator'];
+    $this->user->roles[$role] = $role;
+    user_save($this->user);
+    $this->message['to'] = $this->user->mail;
+    og_group('node', $this->group->nid, array(
+      'entity_type' => 'user',
+      'entity' => $this->user,
+    ));
+    dkan_workflow_mail_alter($this->message);
+
+    $this->assertFalse($this->message['send']);
+  }
+
+  /**
+   * Allow emails to "Worflow Supervisor" when node is groupless.
+   */
+  public function testWorkflowSupervisorGrouplessNode() {
+    $role = $this->roles['Workflow Supervisor'];
+    $this->user->roles[$role] = $role;
+    user_save($this->user);
+    $this->message['to'] = $this->user->mail;
+    dkan_workflow_mail_alter($this->message);
+
+    $this->assertTrue($this->message['send']);
+  }
+
+  /**
+   * Disallow emails to "Workflow Supervisor" when node has group.
+   */
+  public function testWorkflowSupervisorGroupedNode() {
+    $role = $this->roles['Workflow Supervisor'];
+    $this->user->roles[$role] = $role;
+    user_save($this->user);
+    og_group('node', $this->group->nid, array(
+      'entity_type' => 'node',
+      'entity' => $this->message['params']['node'],
+      'field_name' => 'og_group_ref',
+    ));
+    $this->message['to'] = $this->user->mail;
+    dkan_workflow_mail_alter($this->message);
+
+    $this->assertFalse($this->message['send']);
+  }
+
+
+  /**
+   * Overrides parent::tearDown().
+   */
+  public function tearDown() {
+    node_delete($this->group->nid);
+    node_delete($this->group2->nid);
+    node_delete($this->message['params']['node']->nid);
+    user_delete($this->user->uid);
+  }
+
+}

--- a/test/phpunit/DkanWorkflowTest.php
+++ b/test/phpunit/DkanWorkflowTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @file
+ * Unit tests for dkan_workflow functions.
+ */
+
+module_load_include('module', 'dkan_workflow');
+
+/**
+ * Base dkan_workflow unit test class.
+ */
+class DkanWorkflowBaseTest extends PHPUnit_Framework_TestCase {
+
+  /**
+   * Verify that email errors get removed from messages.
+   */
+  public function testDkanWorlflowRemoveEmailErrors() {
+    // When no email error.
+    $error = 'This is not an email error.';
+    drupal_set_message($error, 'error');
+    $expected = ['error' => [$error]];
+    dkan_workflow_remove_email_errors();
+
+    $actual = drupal_get_messages('error');
+    $this->assertEquals($actual, $expected);
+
+    // When mixed email error with regular error.
+    $email_error = 'This is an email notifications error.';
+    $expected = ['error' => [$error]];
+    drupal_set_message($error, 'error');
+    drupal_set_message($email_error, 'error');
+    dkan_workflow_remove_email_errors();
+
+    $actual = drupal_get_messages('error');
+    $this->assertEquals($actual, $expected);
+
+    // When only an email error.
+    $email_error = 'This is an email notifications error.';
+    drupal_set_message($email_error, 'error');
+    $expected = [];
+    dkan_workflow_remove_email_errors();
+
+    $actual = drupal_get_messages('error');
+    $this->assertEquals($actual, $expected);
+  }
+
+}


### PR DESCRIPTION
Ref. nucivic/healthdata#666

This change captures the following business logic:
- [ ] Allow emails to a user if the user is the original author of the node.
- [ ] Allow emails to a "Workflow Moderator" that belongs to the same group as the node.
- [ ] Disallow emails to a "Workflow Moderator" that does not share a group with the node.
- [ ] Allow emails to a "Workflow Supervisor" for a groupless node.
- [ ] Disallow emails to a "Workflow Supervisor" for a grouped node (Does not prevent Workflow Supervisor access).
- [ ] Captures email errors generated as a side effect of the implementation.
