### PR TITLE
Fix errors in the content creation form

### DIFF
--- a/dkan_workflow.module
+++ b/dkan_workflow.module
@@ -108,17 +108,15 @@ function dkan_workflow_form_alter(&$form, $form_state, $form_id) {
  */
 function dkan_workflow_remove_email_errors() {
   $messages = drupal_get_messages('error');
-  if ($messages['error']) {
+  if (array_key_exists('error', $messages)) {
     $messages['error'] = array_filter($messages['error'], function ($item) {
       return FALSE === strpos($item, 'email notifications');
     });
+    $drupal_set_error = function($error) {
+      drupal_set_message($error, 'error');
+    };
+    array_map($drupal_set_error, $messages['error']);
   }
-
-  $drupal_set_error = function($error) {
-    drupal_set_message($error, 'error');
-  };
-
-  array_map($drupal_set_error, $messages['error']);
 }
 
 /**


### PR DESCRIPTION
When I go to node/add/group or node/add/dataset I'm getting this errors.

<img width="1149" alt="screen shot 2015-12-09 at 12 03 48 pm" src="https://cloud.githubusercontent.com/assets/381224/11691327/43edbcfe-9e79-11e5-8b30-e7d7c57becab.png">
### Acceptance tests
- Follow the steps in https://github.com/NuCivic/dkan/pull/684#issue-105583829
- go to node/add/group
- Errors should not be displayed
