### PR TITLE
Fix content type publishing options doesnt show up after install

### DIFF
--- a/dkan_workflow.install
+++ b/dkan_workflow.install
@@ -40,7 +40,7 @@ function dkan_workflow_enable() {
     $node_options = array_diff($node_options, array('status'));
     // Add moderation and revision if needed.
     $node_options = array_values(array_unique(array_merge($node_options, array('moderation', 'revision')), SORT_REGULAR));
-    variable_set($var_name, node_options);
+    variable_set($var_name, $node_options);
   }
 }
 


### PR DESCRIPTION
After enable dkan_worflow "Enable moderation of revisions" isn't being listed in the publishing options in the content type.

<img width="1279" alt="screen shot 2015-12-10 at 4 12 43 pm" src="https://cloud.githubusercontent.com/assets/381224/11725524/f3bfd164-9f58-11e5-8955-fb97bad535bf.png">
## Acceptance tests
- [ ] install dkan worflow using this branch
- [ ] drush en -y dkan_workflow
- [ ] go to admin/structure/types/manage/dataset
- [ ] click in publishing options
- [ ]  "Enable moderation of revisions" should be listed
