### PR TITLE
Fix fatal error in the moderation queues

### DIFF
--- a/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
+++ b/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
@@ -271,8 +271,8 @@ function theme_dkan_workflow_tree_item($variables = NULL) {
     // Parentless title type item.
     // Default to "Others"
     $title = t('Others');
-    if ($variables('title') != NULL) {
-      $title = $variables('title');
+    if ($variables['title'] != NULL) {
+      $title = $variables['title'];
     }
     $output = '<div class="item-content item-disabled">';
     $output .=


### PR DESCRIPTION
If I go to any moderation queue (My Drafts, Needs Review, etc) and there is at least one element in that list an error is thrown.
<img width="1168" alt="fatal_error" src="https://cloud.githubusercontent.com/assets/381224/11748505/63534a5c-a007-11e5-8e3f-45ea20c84e18.png">
## Acceptance test
- [ ] Build a dkan instance with dkan_workflow enabled
- [ ] Create a dataset as workflow contributor and submit that for review
- [ ] Login as administrator
- [ ] Go to admin/workbench/needs-review-active
- [ ] A fatal error shouldn't happen
