### PR TITLE
Add jquery function to enforce role pairing

### DIFF
--- a/modules/dkan_workflow_permissions/dkan_workflow_permissions.js
+++ b/modules/dkan_workflow_permissions/dkan_workflow_permissions.js
@@ -1,0 +1,18 @@
+(function ($) {
+    Drupal.behaviors.checkbox = {
+        // Enforce role pairings defined in dkan_workflow_permissions_form_user_profile_form_alter()
+        attach: function(context, settings) {
+            $('#edit-roles').find('.form-checkbox').on('click', function(event) {
+                rolePairings = settings.dkan_workflow_permissions.rolePairings;
+                var clickedRole = $(this).val();
+                var isChecked = $(this)[0].checked;
+                if (clickedRole in rolePairings) {
+                    // The paired role should have the same checked property as the clicked role
+                    $("#edit-roles-" + rolePairings[clickedRole]).prop('checked', isChecked)
+                        // Coincidentally, the "disabled" attribute should be identical
+                        .attr("disabled", isChecked);
+                }
+            });
+        }
+    }
+})(jQuery);

--- a/modules/dkan_workflow_permissions/dkan_workflow_permissions.module
+++ b/modules/dkan_workflow_permissions/dkan_workflow_permissions.module
@@ -3,3 +3,47 @@
  * @file
  * Drupal needs this blank file.
  */
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Enforce "role pairings" in DKAN Workflow - each workflow role requires a
+ * core role along with it to work.
+ */
+function dkan_workflow_permissions_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'user_profile_form' || $form_id == 'user_register_form') {
+    // Check to see if expected roles even exist. If not, something has been
+    // customized and it's safer to just not do this.
+    $user_roles = user_roles();
+    $required_roles = array(
+      'content creator',
+      'editor',
+      'site manager',
+      'Workflow Contributor',
+      'Workflow Moderator',
+      'Workflow Supervisor',
+    );
+    foreach($required_roles as $required_role) {
+      if (!in_array($required_role, $user_roles)) {
+        // @todo: Add some kind of user warning if this happens.
+        return;
+      }
+    }
+
+    // Define the pairings. The value is required by the key.
+    $rids = array_flip($user_roles);
+    $pairings = array(
+      $rids['Workflow Contributor'] => $rids['content creator'],
+      $rids['Workflow Moderator']   => $rids['editor'],
+      $rids['Workflow Supervisor']  => $rids['site manager'],
+    );
+
+    drupal_add_js(array('dkan_workflow_permissions' => array('rolePairings' => $pairings)), 'setting');
+    $path = drupal_get_path('module', 'dkan_workflow_permissions');
+    $form['account']['roles']['#attached']['js'][] = "$path/dkan_workflow_permissions.js";
+    $form['account']['roles']['#description'] = t('Workflow roles require certain
+      core roles to be enabled. For instance, the "Workflow Contributor" role must
+      always be accompanied by the "content creator" role. Users without any
+      workflow role will not be able to submit or publish content.');
+  }
+}

--- a/test/features/dkan_workflow.feature
+++ b/test/features/dkan_workflow.feature
@@ -13,6 +13,7 @@ Feature:
       | Stale Reviews      | /admin/workbench/needs-review-stale  |
       | My Edits           | /admin/workbench/content/edited      |
       | All Recent Content | /admin/workbench/content/all         |
+      | Create User        | /admin/people/create                 |
 
   @fixme
   # Non workbench roles can see the menu item My Workflow. However
@@ -501,3 +502,13 @@ Feature:
     | Contributor C1G2 | should not |
     | Moderator M1G2   | should not |
     | Supervisor S1G2  | should     |
+
+
+  @api @javascript
+  Scenario: When administering users, role pairings should be enforced
+
+    Given I am logged in as a user with the "administrator" role
+    And I visit the "Create User" page
+    Then the checkbox "content creator" should not be checked
+    And I check the box "Workflow Contributor"
+    Then the checkbox "content creator" should be checked

--- a/test/features/dkan_workflow.feature
+++ b/test/features/dkan_workflow.feature
@@ -505,7 +505,7 @@ Feature:
 
 
   @api @javascript
-  Scenario: When administering users, role pairings should be enforced
+  Scenario: When administering users, role pairings with core roles should be enforced
 
     Given I am logged in as a user with the "administrator" role
     And I visit the "Create User" page


### PR DESCRIPTION
## Description

Some roles in DKAN Workflow expect other "core role" to be enabled in order to have all the functionality required. This form allter and javascript function enforce this at the UI level.
## Acceptance test
- Log in as admin
- Go to `admin/people/create`
- Try toggling the Workflow rules
- The correct corresponding role should be automatically toggled and, if checked, disabled
- Try the same thing editing an existing user
