### PR TITLE
Move My Workbench menu item to command center menu

### DIFF
--- a/dkan-module-init.sh
+++ b/dkan-module-init.sh
@@ -3,7 +3,7 @@
 DKAN_MODULE="dkan_workflow"
 
 # DKAN branch to use
-DKAN_BRANCH="workflow"
+DKAN_BRANCH="workflow-menu-links"
 
 COMPOSER_PATH=".composer/vendor/bin"
 

--- a/dkan-module-init.sh
+++ b/dkan-module-init.sh
@@ -3,7 +3,7 @@
 DKAN_MODULE="dkan_workflow"
 
 # DKAN branch to use
-DKAN_BRANCH="workflow-menu-links"
+DKAN_BRANCH="workflow"
 
 COMPOSER_PATH=".composer/vendor/bin"
 

--- a/dkan_workflow.install
+++ b/dkan_workflow.install
@@ -11,7 +11,7 @@ function dkan_workflow_install() {
   $item = array(
     'link_path' => 'admin/workbench',
     'link_title' => 'My Workbench',
-    'menu_name' => 'main-menu',
+    'menu_name' => 'menu-command-center-menu',
     'weight' => -50,
     'expanded' => 0,
   );


### PR DESCRIPTION
This should fix the last remaining test failure on the `workflow` branch (#20), and depends on the workflow-menu-links branch on dkan (NuCivic/dkan#918).
