### PR TITLE
Update the content type legend below content lists to be accurate

### DIFF
--- a/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.css
+++ b/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.css
@@ -31,6 +31,7 @@
 .references .icon-dkan:before {
   color: #666;
   padding-right: 0;
+  vertical-align: middle;
 }
 
 .views-dkan-workflow-tree-actions {

--- a/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.css
+++ b/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.css
@@ -19,13 +19,18 @@
 }
 
 .references {
-  margin-top: 30px;
-  color: #333333;
+  margin: 30px 0;
+  color: #666;
   padding-left: 20px;
   vertical-align: middle;
+  font-size: .9em;
 }
 .references > span {
-  padding-right: 6px;
+  padding-right: 10px;
+}
+.references .icon-dkan:before {
+  color: #666;
+  padding-right: 0;
 }
 
 .views-dkan-workflow-tree-actions {

--- a/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
+++ b/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
@@ -125,11 +125,23 @@ function views_dkan_workflow_tree_views_bulk_operations_form_alter(&$form, &$for
       'type' => 'data_dashboard',
       'class' => array('icon-dkan')
     );
+    
     $dataset_legend = '<span>'. theme('facet_icons', $dataset_icon) . ' Dataset</span>';
     $resource_legend = '<span>'. theme('facet_icons', $resource_icon) . ' Resource</span>';
     $story_legend = '<span>'. theme('facet_icons', $story_icon) . ' Data Story</span>';
-    $dashboard_icon = '<span>' . theme('facet_icons', $dashboard_icon) . ' Data Dashboard';
-    $form['#suffix'] = "<div class=\"references\"> $dataset_legend $resource_legend $story_legend $dashboard_icon</div>";
+    $dashboard_legend = '<span>' . theme('facet_icons', $dashboard_icon) . ' Data Dashboard</span>';
+
+    if(module_exists('dkan_feedback')) {
+      $feedback_icon = array(
+        'type' => 'feedback',
+        'class' => array('icon-dkan')
+      );
+      $feedback_legend = '<span>'. theme('facet_icons', $feedback_icon) . ' Feedback</span>';
+      $form['#suffix'] = "<div class=\"references\"> $dataset_legend $resource_legend $story_legend $dashboard_legend $feedback_legend</div>";
+    }
+    else {
+      $form['#suffix'] = "<div class=\"references\"> $dataset_legend $resource_legend $story_legend $dashboard_legend</div>";
+    }
   }
 }
 

--- a/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
+++ b/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
@@ -111,20 +111,25 @@ function views_dkan_workflow_tree_views_bulk_operations_form_alter(&$form, &$for
 
     $dataset_icon = array(
       'type' => 'dataset',
-      'class' => array('facet-icon')
+      'class' => array('icon-dkan')
     );
     $resource_icon = array(
       'type' => 'resource',
-      'class' => array('facet-icon')
+      'class' => array('icon-dkan')
     );
-    $feedback_icon = array(
-      'type' => 'resource',
-      'class' => array('facet-icon')
+    $story_icon = array(
+      'type' => 'dkan_data_story',
+      'class' => array('icon-dkan')
+    );
+    $dashboard_icon = array(
+      'type' => 'data_dashboard',
+      'class' => array('icon-dkan')
     );
     $dataset_legend = '<span>'. theme('facet_icons', $dataset_icon) . ' Dataset</span>';
     $resource_legend = '<span>'. theme('facet_icons', $resource_icon) . ' Resource</span>';
-    $feedback_legend = '<span>'. theme('facet_icons', $feedback_icon) . ' Feedback</span>';
-    $form['#suffix'] = "<div class=\"references\"> $dataset_legend $resource_legend $feedback_legend</div>";
+    $story_legend = '<span>'. theme('facet_icons', $story_icon) . ' Data Story</span>';
+    $dashboard_icon = '<span>' . theme('facet_icons', $dashboard_icon) . ' Data Dashboard';
+    $form['#suffix'] = "<div class=\"references\"> $dataset_legend $resource_legend $story_legend $dashboard_icon</div>";
   }
 }
 


### PR DESCRIPTION
## QA site on dkan repo

https://github.com/NuCivic/dkan/pull/1302
## Description

The legend displayed on the workbench pages lists 'Feedback' which is not a standard dkan content type. The legend should also be themed to not look like links and have spacing added below so that it does not run up against instructional text below it.
## Steps to Reproduce
1. Enable dkan_workflow
2. Visit the My Workbench page, and the child pages that list content.

![screenshot_4_5_16__11_12_am-2](https://cloud.githubusercontent.com/assets/314172/14289213/6e4913e2-fb1f-11e5-928b-9a52281ee6f0.png)
## Acceptance Criteria
1. Enable dkan_workflow
2. Edit a resource or dataset
3. Click on My Workbench link in the admin menu
4. Click My Drafts
5. Confirm the content type legend at the bottom is correct

The 'legend' should also be themed to indicate these are not links and there is adequate spacing between the icons and any instructional text below it.

![screenshot_4_5_16__11_11_am](https://cloud.githubusercontent.com/assets/314172/14289314/d7dbd876-fb1f-11e5-8768-60294a3d62bb.png)

**With dkan_feedback enabled**

![my_drafts___dkan](https://cloud.githubusercontent.com/assets/314172/17417712/4b06ad50-5a5a-11e6-8a4f-2f7d62a64516.png)
