### PR TITLE
Update workbench_moderation to dev branch

### DIFF
--- a/dkan_workflow.make
+++ b/dkan_workflow.make
@@ -4,8 +4,9 @@ api = 2
 projects[workbench][version] = 1.2
 projects[workbench][subdir] = contrib
 
-projects[workbench_moderation][version] = 1.4
+projects[workbench_moderation][version] = 7.x-1.x-dev
 projects[workbench_moderation][subdir] = contrib
+projects[workbench_moderation][download][revision] = "2c91211"
 projects[workbench_moderation][patch][2393771] = https://www.drupal.org/files/issues/specify_change_state_user-2393771-5.patch
 projects[workbench_moderation][patch][1838640] = https://www.drupal.org/files/issues/workbench_moderation-fix_callback_argument-1838640-23.patch
 

--- a/dkan_workflow.make
+++ b/dkan_workflow.make
@@ -4,9 +4,11 @@ api = 2
 projects[workbench][version] = 1.2
 projects[workbench][subdir] = contrib
 
-projects[workbench_moderation][version] = 7.x-1.x-dev
-projects[workbench_moderation][subdir] = contrib
+projects[workbench_moderation][download][type] = git
+projects[workbench_moderation][download][url] = http://git.drupal.org/project/workbench_moderation.git
+projects[workbench_moderation][download][branch] = 1.x-dev
 projects[workbench_moderation][download][revision] = "2c91211"
+projects[workbench_moderation][subdir] = contrib
 projects[workbench_moderation][patch][2393771] = https://www.drupal.org/files/issues/specify_change_state_user-2393771-5.patch
 projects[workbench_moderation][patch][1838640] = https://www.drupal.org/files/issues/workbench_moderation-fix_callback_argument-1838640-23.patch
 

--- a/dkan_workflow.make
+++ b/dkan_workflow.make
@@ -5,8 +5,7 @@ projects[workbench][version] = 1.2
 projects[workbench][subdir] = contrib
 
 projects[workbench_moderation][download][type] = git
-projects[workbench_moderation][download][url] = http://git.drupal.org/project/workbench_moderation.git
-projects[workbench_moderation][download][branch] = 1.x-dev
+projects[workbench_moderation][download][branch] = 7.x-1.x
 projects[workbench_moderation][download][revision] = "2c91211"
 projects[workbench_moderation][subdir] = contrib
 projects[workbench_moderation][patch][2393771] = https://www.drupal.org/files/issues/specify_change_state_user-2393771-5.patch


### PR DESCRIPTION
This upgrades workbench_moderation to the current 1.x dev revision, which adds pagination to the moderation page in workbench. Without this, the moderation page can crash or time out on nodes with more than 50 revisions - an edge case, but one we have encountered when the Harvester updates nodes more frequently than expected.
