### PR TITLE
civic-3229: Fix feedback reference icon

### DIFF
--- a/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
+++ b/modules/views_dkan_workflow_tree/views_dkan_workflow_tree.module
@@ -118,7 +118,7 @@ function views_dkan_workflow_tree_views_bulk_operations_form_alter(&$form, &$for
       'class' => array('facet-icon')
     );
     $feedback_icon = array(
-      'type' => 'resource',
+      'type' => 'feedback',
       'class' => array('facet-icon')
     );
     $dataset_legend = '<span>'. theme('facet_icons', $dataset_icon) . ' Dataset</span>';


### PR DESCRIPTION
# Description

In the reference section at the bottom of Workflow, view feedback has the wrong icon

![wrong_icon_for_feedback](https://cloud.githubusercontent.com/assets/1775858/16652756/fd24642e-444c-11e6-90c9-5436ca4f6cf0.png)

It should be like this 

![selection_509](https://cloud.githubusercontent.com/assets/1775858/16652764/09e23a4c-444d-11e6-83c1-a010548b3ab9.png)

ref https://jira.govdelivery.com/browse/CIVIC-3229
