### PR TITLE
Add workflow roles to assignroles settings

### DIFF
--- a/dkan_workflow.install
+++ b/dkan_workflow.install
@@ -48,4 +48,17 @@ function dkan_workflow_enable() {
   }
   dkan_workflow_revert_views();
   variable_set('dkan_workflow_content_types', $dkan_workflow_content_types);
+  // Add dkan workflow roles to roleassign config.
+  $roles = variable_get('roleassign_roles', array());
+  $add_roles = array('Workflow Contributor' => 'Workflow Contributor', 'Workflow Moderator' => 'Workflow Moderator', 'Workflow Supervisor' => 'Workflow Supervisor');
+  $new_roles = array_merge($roles, $add_roles);
+  variable_set('roleassign_roles', $new_roles);
+}
+
+/**
+ * Implements hook_disable().
+ */
+function dkan_workflow_disable() {
+  $roles = array('editor' => 'editor', 'site manager' => 'site manager', 'content creator' => 'content creator', 'administrator' => 0);
+  variable_set('roleassign_roles', $roles);
 }

--- a/dkan_workflow.install
+++ b/dkan_workflow.install
@@ -23,11 +23,11 @@ function dkan_workflow_install() {
 
 /**
  * Implements hook_enable().
- *
- * Enable moderation for dkan_workflow enabled content types upon install. This
- * config is kept persistante using the hook_strongarm_alter().
  */
 function dkan_workflow_enable() {
+
+  // Enable moderation for dkan_workflow enabled content types upon install. This
+  // config is kept persistant using the hook_strongarm_alter().
 
   // Default dkan content types with moderation.
   $dkan_workflow_content_types = array('dataset', 'resource', 'feedback');
@@ -48,17 +48,33 @@ function dkan_workflow_enable() {
   }
   dkan_workflow_revert_views();
   variable_set('dkan_workflow_content_types', $dkan_workflow_content_types);
+
   // Add dkan workflow roles to roleassign config.
-  $roles = variable_get('roleassign_roles', array());
-  $add_roles = array('Workflow Contributor' => 'Workflow Contributor', 'Workflow Moderator' => 'Workflow Moderator', 'Workflow Supervisor' => 'Workflow Supervisor');
-  $new_roles = array_merge($roles, $add_roles);
-  variable_set('roleassign_roles', $new_roles);
+  $roleassign_roles = variable_get('roleassign_roles', array());
+  $roles_rids = array_flip(user_roles());
+
+  $add_roles = array('Workflow Contributor', 'Workflow Moderator', 'Workflow Supervisor');
+
+  foreach($add_roles as $role) {
+    $roleassign_roles[$roles_rids[$role]] = (string) $roles_rids[$role];
+  }
+
+  variable_set('roleassign_roles', $roleassign_roles);
 }
 
 /**
  * Implements hook_disable().
  */
 function dkan_workflow_disable() {
-  $roles = array('editor' => 'editor', 'site manager' => 'site manager', 'content creator' => 'content creator', 'administrator' => 0);
-  variable_set('roleassign_roles', $roles);
+  // Remove workflow roles from roleassign_roles variable
+  $roleassign_roles = variable_get('roleassign_roles', array());
+  $roles_rids = array_flip(user_roles());
+  $remove_roles = array('Workflow Contributor', 'Workflow Moderator', 'Workflow Supervisor');
+
+  foreach($remove_roles as $role) {
+    unset($roleassign_roles[$roles_rids[$role]]);
+  }
+
+  variable_set('roleassign_roles', $roleassign_roles);
+
 }

--- a/test/features/dkan_workflow.feature
+++ b/test/features/dkan_workflow.feature
@@ -520,3 +520,23 @@ Feature:
     When I click "Contributor RolePairing"
     And I click "Edit"
     Then the checkbox "content creator" should be checked
+
+  @api
+  Scenario: Modify user workflow roles as site manager
+    Given users:
+      | name     | roles           |
+      | Pat      | content creator |
+      | Chris    | site manager    |
+    Given pages:
+      | name          | url           |
+      | Users         | /admin/people |
+
+    Given I am logged in as "Chris"
+    And I am on "Users" page
+    When I click "edit" in the "Pat" row
+    And I check "Workflow Contributor"
+    And I press "Save"
+    And I wait for "People"
+    Then I should see "The changes have been saved"
+    When I am on "Users" page
+    Then I should see "Workflow Contributor" in the "Pat" row


### PR DESCRIPTION
civic-3475
## Description

When dkan_workflow is enabled, site managers need to be able to assign the new roles to users.
## PR dependency

https://github.com/NuCivic/dkan/pull/1250
