### PR TITLE
Fix menu source for dkan workflow roles

### DIFF
--- a/dkan_workflow.install
+++ b/dkan_workflow.install
@@ -58,8 +58,8 @@ function dkan_workflow_enable() {
   foreach($add_roles as $role) {
     $roleassign_roles[$roles_rids[$role]] = (string) $roles_rids[$role];
   }
-
   variable_set('roleassign_roles', $roleassign_roles);
+  dkan_workflow_admin_menu_source();
 }
 
 /**
@@ -74,7 +74,37 @@ function dkan_workflow_disable() {
   foreach($remove_roles as $role) {
     unset($roleassign_roles[$roles_rids[$role]]);
   }
-
   variable_set('roleassign_roles', $roleassign_roles);
+}
 
+/**
+ * This helper function sets up the admin_menu_source module's configuration.
+ * We want the content creator and editor roles to have the "command center"
+ * menu rather than the whole admin menu in the top bar. We can't rely on the
+ * rid to be the same on every site so not using features.
+ */
+function dkan_workflow_admin_menu_source() {
+  drupal_flush_all_caches();
+  $roles = array_flip(user_roles());
+
+  $admin_menu_source_settings = array(
+    $roles['Workflow Contributor'] => array(
+      'rid' => $roles['Workflow Contributor'],
+      'source' => 'menu-command-center-menu',
+      'weight' => 4,
+    ),
+    $roles['Workflow Moderator'] => array(
+      'rid' => $roles['Workflow Moderator'],
+      'source' => 'menu-command-center-menu',
+      'weight' => 5,
+    ),
+    $roles['Workflow Supervisor'] => array(
+      'rid' => $roles['Workflow Supervisor'],
+      'source' => 'menu-command-center-menu',
+      'weight' => 6,
+    ),
+  );
+  $previous_settings = variable_get('admin_menu_source_settings');
+  $admin_menu_source_settings = array_replace($previous_settings, $admin_menu_source_settings);
+  variable_set('admin_menu_source_settings', $admin_menu_source_settings);
 }


### PR DESCRIPTION
Issue: civic-5267

## Description
Admin menu source weren't properly configured for dkan_workflow roles. So we needed to add function to configure the source menu for those roles during the install. We also needed to create hook_update to fix this in the current instances.

## PR Dependencies
https://github.com/NuCivic/dkan/pull/1664